### PR TITLE
👷 [+ci] CI Workaround (Change 1 of N)

### DIFF
--- a/src/SimpleSchema/setup.py
+++ b/src/SimpleSchema/setup.py
@@ -34,7 +34,7 @@ from Common_Foundation import SubprocessEx
 _this_dir                                   = Path(__file__).parent
 _name                                       = _this_dir.name
 
-_initial_year                               = 2023
+_initial_year                               = 2023  # pylint: disable=invalid-name
 
 
 # ----------------------------------------------------------------------
@@ -47,7 +47,8 @@ with ExitStack(lambda: sys.path.pop(0)):
 # ----------------------------------------------------------------------
 def _GetVersion() -> str:
     result = SubprocessEx.Run(
-        'AutoSemVer{ext} Generate --no-metadata --style AllMetadata --quiet'.format(
+        # TODO: 'AutoSemVer{ext} Generate --no-metadata --style AllMetadata --quiet'.format(
+            'AutoSemVer{ext} Generate --no-branch-name --no-metadata --style AllMetadata --quiet'.format( # TODO
             ext=CurrentShell.script_extensions[0],
         ),
         cwd=_this_dir,
@@ -56,7 +57,7 @@ def _GetVersion() -> str:
     assert result.returncode == 0, result.output
     return result.output.strip()
 
-_version = _GetVersion()
+_version = _GetVersion()  # pylint: disable=invalid-name
 del _GetVersion
 
 


### PR DESCRIPTION
This is a workaround for a bug discovered while fixing another bug.

1) SimpleSchema could not be built on the CI machine because the detached head state wasn't resolving to a mainline branch.

2) This fix had to happen in Common_Foundation, but there was a bug in its dependency scripts where it wasn't properly setting this repository's branch.

So, the fix is to temporarily disable the use of branches in SimpleSchema's setup, let that make it to SimpleSchema's main_stable branch, let Common_Foundation's main_stable cover the AutoSemVer issue (now that SimpleSchema won't be failing), then revert this change to allow SimpleSchema to continue.